### PR TITLE
Move exceptions to Cog\Contracts namespace

### DIFF
--- a/contracts/Authenticator/Exceptions/AuthenticationException.php
+++ b/contracts/Authenticator/Exceptions/AuthenticationException.php
@@ -11,14 +11,16 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Cog\YouTrack\Rest\Authorizer\Exceptions;
+namespace Cog\Contracts\YouTrack\Rest\Authenticator\Exceptions;
+
+use Cog\Contracts\YouTrack\Rest\Client\Exceptions\ClientException;
 
 /**
- * Class InvalidTokenException.
+ * Class AuthenticationException.
  *
- * @package Cog\YouTrack\Rest\Authorizer\Exceptions
+ * @package Cog\Contracts\YouTrack\Rest\Authenticator\Exceptions
  */
-class InvalidTokenException extends AuthorizationException
+class AuthenticationException extends ClientException
 {
     //
 }

--- a/contracts/Authorizer/Exceptions/AuthorizationException.php
+++ b/contracts/Authorizer/Exceptions/AuthorizationException.php
@@ -11,16 +11,16 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Cog\YouTrack\Rest\HttpClient\Exceptions;
+namespace Cog\Contracts\YouTrack\Rest\Authorizer\Exceptions;
 
-use Exception;
+use Cog\Contracts\YouTrack\Rest\Client\Exceptions\ClientException;
 
 /**
- * Class HttpClientException.
+ * Class AuthorizationException.
  *
- * @package Cog\YouTrack\Rest\HttpClient\Exceptions
+ * @package Cog\Contracts\YouTrack\Rest\Authorizer\Exceptions
  */
-class HttpClientException extends Exception
+class AuthorizationException extends ClientException
 {
     //
 }

--- a/contracts/Authorizer/Exceptions/InvalidTokenException.php
+++ b/contracts/Authorizer/Exceptions/InvalidTokenException.php
@@ -11,16 +11,14 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Cog\YouTrack\Rest\Authorizer\Exceptions;
-
-use Cog\YouTrack\Rest\Client\Exceptions\ClientException;
+namespace Cog\Contracts\YouTrack\Rest\Authorizer\Exceptions;
 
 /**
- * Class AuthorizationException.
+ * Class InvalidTokenException.
  *
- * @package Cog\YouTrack\Rest\Authorizer\Exceptions
+ * @package Cog\Contracts\YouTrack\Rest\Authorizer\Exceptions
  */
-class AuthorizationException extends ClientException
+class InvalidTokenException extends AuthorizationException
 {
     //
 }

--- a/contracts/Client/Client.php
+++ b/contracts/Client/Client.php
@@ -36,9 +36,9 @@ interface Client
      * @param array $options
      * @return \Cog\Contracts\YouTrack\Rest\Response\Response
      *
-     * @throws \Cog\YouTrack\Rest\Authenticator\Exceptions\AuthenticationException
-     * @throws \Cog\YouTrack\Rest\Authorizer\Exceptions\InvalidTokenException
-     * @throws \Cog\YouTrack\Rest\Client\Exceptions\ClientException
+     * @throws \Cog\Contracts\YouTrack\Rest\Authenticator\Exceptions\AuthenticationException
+     * @throws \Cog\Contracts\YouTrack\Rest\Authorizer\Exceptions\InvalidTokenException
+     * @throws \Cog\Contracts\YouTrack\Rest\Client\Exceptions\ClientException
      */
     public function request(string $method, string $uri, array $params = [], array $options = []): ResponseContract;
 
@@ -50,9 +50,9 @@ interface Client
      * @param array $options
      * @return \Cog\Contracts\YouTrack\Rest\Response\Response
      *
-     * @throws \Cog\YouTrack\Rest\Authenticator\Exceptions\AuthenticationException
-     * @throws \Cog\YouTrack\Rest\Authorizer\Exceptions\InvalidTokenException
-     * @throws \Cog\YouTrack\Rest\Client\Exceptions\ClientException
+     * @throws \Cog\Contracts\YouTrack\Rest\Authenticator\Exceptions\AuthenticationException
+     * @throws \Cog\Contracts\YouTrack\Rest\Authorizer\Exceptions\InvalidTokenException
+     * @throws \Cog\Contracts\YouTrack\Rest\Client\Exceptions\ClientException
      */
     public function get(string $uri, array $params = [], array $options = []): ResponseContract;
 
@@ -64,9 +64,9 @@ interface Client
      * @param array $options
      * @return \Cog\Contracts\YouTrack\Rest\Response\Response
      *
-     * @throws \Cog\YouTrack\Rest\Authenticator\Exceptions\AuthenticationException
-     * @throws \Cog\YouTrack\Rest\Authorizer\Exceptions\InvalidTokenException
-     * @throws \Cog\YouTrack\Rest\Client\Exceptions\ClientException
+     * @throws \Cog\Contracts\YouTrack\Rest\Authenticator\Exceptions\AuthenticationException
+     * @throws \Cog\Contracts\YouTrack\Rest\Authorizer\Exceptions\InvalidTokenException
+     * @throws \Cog\Contracts\YouTrack\Rest\Client\Exceptions\ClientException
      */
     public function post(string $uri, array $params = [], array $options = []): ResponseContract;
 
@@ -78,9 +78,9 @@ interface Client
      * @param array $options
      * @return \Cog\Contracts\YouTrack\Rest\Response\Response
      *
-     * @throws \Cog\YouTrack\Rest\Authenticator\Exceptions\AuthenticationException
-     * @throws \Cog\YouTrack\Rest\Authorizer\Exceptions\InvalidTokenException
-     * @throws \Cog\YouTrack\Rest\Client\Exceptions\ClientException
+     * @throws \Cog\Contracts\YouTrack\Rest\Authenticator\Exceptions\AuthenticationException
+     * @throws \Cog\Contracts\YouTrack\Rest\Authorizer\Exceptions\InvalidTokenException
+     * @throws \Cog\Contracts\YouTrack\Rest\Client\Exceptions\ClientException
      */
     public function put(string $uri, array $params = [], array $options = []): ResponseContract;
 
@@ -92,9 +92,9 @@ interface Client
      * @param array $options
      * @return \Cog\Contracts\YouTrack\Rest\Response\Response
      *
-     * @throws \Cog\YouTrack\Rest\Authenticator\Exceptions\AuthenticationException
-     * @throws \Cog\YouTrack\Rest\Authorizer\Exceptions\InvalidTokenException
-     * @throws \Cog\YouTrack\Rest\Client\Exceptions\ClientException
+     * @throws \Cog\Contracts\YouTrack\Rest\Authenticator\Exceptions\AuthenticationException
+     * @throws \Cog\Contracts\YouTrack\Rest\Authorizer\Exceptions\InvalidTokenException
+     * @throws \Cog\Contracts\YouTrack\Rest\Client\Exceptions\ClientException
      */
     public function delete(string $uri, array $params = [], array $options = []): ResponseContract;
 

--- a/contracts/Client/Exceptions/ClientException.php
+++ b/contracts/Client/Exceptions/ClientException.php
@@ -11,16 +11,16 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Cog\YouTrack\Rest\Authenticator\Exceptions;
+namespace Cog\Contracts\YouTrack\Rest\Client\Exceptions;
 
-use Cog\YouTrack\Rest\Client\Exceptions\ClientException;
+use Exception;
 
 /**
- * Class AuthenticationException.
+ * Class ClientException.
  *
- * @package Cog\YouTrack\Rest\Authenticator\Exceptions
+ * @package Cog\Contracts\YouTrack\Rest\Client\Exceptions
  */
-class AuthenticationException extends ClientException
+class ClientException extends Exception
 {
     //
 }

--- a/contracts/HttpClient/Exceptions/HttpClientException.php
+++ b/contracts/HttpClient/Exceptions/HttpClientException.php
@@ -11,16 +11,16 @@ declare(strict_types=1);
  * file that was distributed with this source code.
  */
 
-namespace Cog\YouTrack\Rest\Client\Exceptions;
+namespace Cog\Contracts\YouTrack\Rest\HttpClient\Exceptions;
 
 use Exception;
 
 /**
- * Class ClientException.
+ * Class HttpClientException.
  *
- * @package Cog\YouTrack\Rest\Client\Exceptions
+ * @package Cog\Contracts\YouTrack\Rest\HttpClient\Exceptions
  */
-class ClientException extends Exception
+class HttpClientException extends Exception
 {
     //
 }

--- a/contracts/HttpClient/HttpClient.php
+++ b/contracts/HttpClient/HttpClient.php
@@ -30,7 +30,7 @@ interface HttpClient
      * @param array $options Additional Options
      * @return \Psr\Http\Message\ResponseInterface Raw response from the server
      *
-     * @throws \Cog\YouTrack\Rest\HttpClient\Exceptions\HttpClientException
+     * @throws \Cog\Contracts\YouTrack\Rest\HttpClient\Exceptions\HttpClientException
      */
     public function request(string $method, string $uri, array $options = []): ResponseInterface;
 }

--- a/src/Authenticator/CookieAuthenticator.php
+++ b/src/Authenticator/CookieAuthenticator.php
@@ -63,7 +63,7 @@ class CookieAuthenticator implements AuthenticatorContract
      * @param \Cog\Contracts\YouTrack\Rest\Client\Client $client
      * @return void
      *
-     * @throws \Cog\YouTrack\Rest\Authenticator\Exceptions\AuthenticationException
+     * @throws \Cog\Contracts\YouTrack\Rest\Authenticator\Exceptions\AuthenticationException
      */
     public function authenticate(ClientContract $client): void
     {

--- a/src/Client/YouTrackClient.php
+++ b/src/Client/YouTrackClient.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace Cog\YouTrack\Rest\Client;
 
-use Cog\YouTrack\Rest\Authenticator\Exceptions\AuthenticationException;
+use Cog\Contracts\YouTrack\Rest\Authenticator\Exceptions\AuthenticationException;
 use Cog\Contracts\YouTrack\Rest\Authorizer\Authorizer as AuthorizerContract;
-use Cog\YouTrack\Rest\Authorizer\Exceptions\InvalidTokenException;
+use Cog\Contracts\YouTrack\Rest\Authorizer\Exceptions\InvalidTokenException;
 use Cog\Contracts\YouTrack\Rest\Client\Client as RestClientContract;
-use Cog\YouTrack\Rest\Client\Exceptions\ClientException;
+use Cog\Contracts\YouTrack\Rest\Client\Exceptions\ClientException;
+use Cog\Contracts\YouTrack\Rest\HttpClient\Exceptions\HttpClientException;
 use Cog\Contracts\YouTrack\Rest\HttpClient\HttpClient as HttpClientContract;
-use Cog\YouTrack\Rest\HttpClient\Exceptions\HttpClientException;
 use Cog\Contracts\YouTrack\Rest\Response\Response as ResponseContract;
 use Cog\YouTrack\Rest\Response\YouTrackResponse;
 
@@ -84,9 +84,9 @@ class YouTrackClient implements RestClientContract
      * @param array $options
      * @return \Cog\Contracts\YouTrack\Rest\Response\Response
      *
-     * @throws \Cog\YouTrack\Rest\Authenticator\Exceptions\AuthenticationException
-     * @throws \Cog\YouTrack\Rest\Authorizer\Exceptions\InvalidTokenException
-     * @throws \Cog\YouTrack\Rest\Client\Exceptions\ClientException
+     * @throws \Cog\Contracts\YouTrack\Rest\Authenticator\Exceptions\AuthenticationException
+     * @throws \Cog\Contracts\YouTrack\Rest\Authorizer\Exceptions\InvalidTokenException
+     * @throws \Cog\Contracts\YouTrack\Rest\Client\Exceptions\ClientException
      */
     public function request(string $method, string $uri, array $params = [], array $options = []) : ResponseContract
     {
@@ -117,9 +117,9 @@ class YouTrackClient implements RestClientContract
      * @param array $options
      * @return \Cog\Contracts\YouTrack\Rest\Response\Response
      *
-     * @throws \Cog\YouTrack\Rest\Authenticator\Exceptions\AuthenticationException
-     * @throws \Cog\YouTrack\Rest\Authorizer\Exceptions\InvalidTokenException
-     * @throws \Cog\YouTrack\Rest\Client\Exceptions\ClientException
+     * @throws \Cog\Contracts\YouTrack\Rest\Authenticator\Exceptions\AuthenticationException
+     * @throws \Cog\Contracts\YouTrack\Rest\Authorizer\Exceptions\InvalidTokenException
+     * @throws \Cog\Contracts\YouTrack\Rest\Client\Exceptions\ClientException
      */
     public function get(string $uri, array $params = [], array $options = []): ResponseContract
     {
@@ -134,9 +134,9 @@ class YouTrackClient implements RestClientContract
      * @param array $options
      * @return \Cog\Contracts\YouTrack\Rest\Response\Response
      *
-     * @throws \Cog\YouTrack\Rest\Authenticator\Exceptions\AuthenticationException
-     * @throws \Cog\YouTrack\Rest\Authorizer\Exceptions\InvalidTokenException
-     * @throws \Cog\YouTrack\Rest\Client\Exceptions\ClientException
+     * @throws \Cog\Contracts\YouTrack\Rest\Authenticator\Exceptions\AuthenticationException
+     * @throws \Cog\Contracts\YouTrack\Rest\Authorizer\Exceptions\InvalidTokenException
+     * @throws \Cog\Contracts\YouTrack\Rest\Client\Exceptions\ClientException
      */
     public function post(string $uri, array $params = [], array $options = []): ResponseContract
     {
@@ -151,9 +151,9 @@ class YouTrackClient implements RestClientContract
      * @param array $options
      * @return \Cog\Contracts\YouTrack\Rest\Response\Response
      *
-     * @throws \Cog\YouTrack\Rest\Authenticator\Exceptions\AuthenticationException
-     * @throws \Cog\YouTrack\Rest\Authorizer\Exceptions\InvalidTokenException
-     * @throws \Cog\YouTrack\Rest\Client\Exceptions\ClientException
+     * @throws \Cog\Contracts\YouTrack\Rest\Authenticator\Exceptions\AuthenticationException
+     * @throws \Cog\Contracts\YouTrack\Rest\Authorizer\Exceptions\InvalidTokenException
+     * @throws \Cog\Contracts\YouTrack\Rest\Client\Exceptions\ClientException
      */
     public function put(string $uri, array $params = [], array $options = []): ResponseContract
     {
@@ -168,9 +168,9 @@ class YouTrackClient implements RestClientContract
      * @param array $options
      * @return \Cog\Contracts\YouTrack\Rest\Response\Response
      *
-     * @throws \Cog\YouTrack\Rest\Authenticator\Exceptions\AuthenticationException
-     * @throws \Cog\YouTrack\Rest\Authorizer\Exceptions\InvalidTokenException
-     * @throws \Cog\YouTrack\Rest\Client\Exceptions\ClientException
+     * @throws \Cog\Contracts\YouTrack\Rest\Authenticator\Exceptions\AuthenticationException
+     * @throws \Cog\Contracts\YouTrack\Rest\Authorizer\Exceptions\InvalidTokenException
+     * @throws \Cog\Contracts\YouTrack\Rest\Client\Exceptions\ClientException
      */
     public function delete(string $uri, array $params = [], array $options = []): ResponseContract
     {

--- a/src/HttpClient/GuzzleHttpClient.php
+++ b/src/HttpClient/GuzzleHttpClient.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Cog\YouTrack\Rest\HttpClient;
 
 use Cog\Contracts\YouTrack\Rest\HttpClient\HttpClient as HttpClientContract;
-use Cog\YouTrack\Rest\HttpClient\Exceptions\HttpClientException;
+use Cog\Contracts\YouTrack\Rest\HttpClient\Exceptions\HttpClientException;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\BadResponseException;
 use GuzzleHttp\Exception\RequestException;
@@ -53,7 +53,7 @@ class GuzzleHttpClient implements HttpClientContract
      * @param array $options Additional Options
      * @return \Psr\Http\Message\ResponseInterface Raw response from the server
      *
-     * @throws \Cog\YouTrack\Rest\HttpClient\Exceptions\HttpClientException
+     * @throws \Cog\Contracts\YouTrack\Rest\HttpClient\Exceptions\HttpClientException
      */
     public function request(string $method, string $uri, array $options = []): ResponseInterface
     {

--- a/tests/Feature/Authenticator/CookieAuthorizerTest.php
+++ b/tests/Feature/Authenticator/CookieAuthorizerTest.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Cog\YouTrack\Rest\Tests\Feature\Authorizer;
 
 use Cog\YouTrack\Rest\Authenticator\CookieAuthenticator;
-use Cog\YouTrack\Rest\Authenticator\Exceptions\AuthenticationException;
+use Cog\Contracts\YouTrack\Rest\Authenticator\Exceptions\AuthenticationException;
 use Cog\YouTrack\Rest\Authorizer\CookieAuthorizer;
 use Cog\YouTrack\Rest\Client\YouTrackClient;
 use Cog\YouTrack\Rest\HttpClient\GuzzleHttpClient;

--- a/tests/Feature/Authenticator/TokenAuthorizerTest.php
+++ b/tests/Feature/Authenticator/TokenAuthorizerTest.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Cog\YouTrack\Rest\Tests\Feature\Authorizer;
 
-use Cog\YouTrack\Rest\Authorizer\Exceptions\InvalidTokenException;
+use Cog\Contracts\YouTrack\Rest\Authorizer\Exceptions\InvalidTokenException;
 use Cog\YouTrack\Rest\Authorizer\TokenAuthorizer;
 use Cog\YouTrack\Rest\Client\YouTrackClient;
 use Cog\YouTrack\Rest\HttpClient\GuzzleHttpClient;


### PR DESCRIPTION
Exceptions should be located in Contracts namespace because interfaces must describe all possible exceptions which could be thrown.