### PR TITLE
Release 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ sudo: false
 
 php:
   - 7.1
+  - 7.2
 
 env:
   global:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to `youtrack-rest-php` will be documented in this file.
 
+## [5.0.0] - 2017-09-13
+
+## Changed
+
+- Exceptions moved to `Cog\Contracts\YouTrack` namespace ([#34](https://github.com/cybercog/youtrack-rest-php/pull/34)).
+
 ## [4.0.0] - 2017-08-27
 
 ### Changed
@@ -60,6 +66,7 @@ All notable changes to `youtrack-rest-php` will be documented in this file.
 
 - Initial release.
 
+[5.0.0]: https://github.com/cybercog/youtrack-rest-php/compare/4.0.0...5.0.0
 [4.0.0]: https://github.com/cybercog/youtrack-rest-php/compare/3.2.0...4.0.0
 [3.2.0]: https://github.com/cybercog/youtrack-rest-php/compare/3.1.1...3.2.0
 [3.1.0]: https://github.com/cybercog/youtrack-rest-php/compare/3.0.0...3.1.0

--- a/composer.json
+++ b/composer.json
@@ -42,9 +42,9 @@
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^1.11",
         "mockery/mockery": "^0.9.8",
-        "orchestra/database": "~3.4.0",
-        "orchestra/testbench": "~3.4.0",
-        "phpunit/phpunit": "^5.7"
+        "orchestra/database": "~3.5.0",
+        "orchestra/testbench": "~3.5.0",
+        "phpunit/phpunit": "^6.0"
     },
     "autoload": {
         "psr-4": {

--- a/contracts/Client/Client.php
+++ b/contracts/Client/Client.php
@@ -25,7 +25,7 @@ interface Client
     /**
      * Version of YouTrack REST PHP client.
      */
-    const VERSION = '4.0.0';
+    const VERSION = '5.0.0';
 
     /**
      * Create and send an HTTP request.


### PR DESCRIPTION
## Changed

- Exceptions moved to `Cog\Contracts\YouTrack` namespace ([#34](https://github.com/cybercog/youtrack-rest-php/pull/34)).
- Upgraded PHPUnit to 6.0