### PR TITLE
Make endpoint path prefix relative

### DIFF
--- a/src/Client/YouTrackClient.php
+++ b/src/Client/YouTrackClient.php
@@ -54,7 +54,7 @@ class YouTrackClient implements RestClientContract
      * @todo choose good name
      * @var string
      */
-    private $endpointPathPrefix = '/rest';
+    private $endpointPathPrefix = 'rest';
 
     /**
      * Request headers.


### PR DESCRIPTION
This will allow connecting with rest api on subpath FE: https://subdomain.myjetbrains.com/youtrack
Otherwise it will use http://subdomain.myjetbrains.com as `base_uri` even if you set `base_uri` to `https://subdomain.myjetbrains.com/youtrack/` 

This should also resolve #27 without need to make `endpointPathPrefix` configurable. 
