### PR TITLE
endpoint prefix changed from 'rest' to 'api'

### DIFF
--- a/src/Client/YouTrackClient.php
+++ b/src/Client/YouTrackClient.php
@@ -70,7 +70,7 @@ class YouTrackClient implements
     {
         $this->httpClient = $httpClient;
         $this->authorizer = $authorizer;
-        $this->endpointPathPrefix = $endpointPathPrefix !== null ? $endpointPathPrefix : 'rest';
+        $this->endpointPathPrefix = $endpointPathPrefix !== null ? $endpointPathPrefix : 'api';
     }
 
     /**


### PR DESCRIPTION
According to the YouTrack documentation:

"On February 17, 2021, we announced discontinuing the legacy REST API If your application uses legacy endpoints that start with the /rest prefix, review and adjust your code to use the new REST API that uses /api prefix and is described in this reference."