### PR TITLE
YouTrack API requires Content-Type headers

### DIFF
--- a/src/Authorizer/CookieAuthorizer.php
+++ b/src/Authorizer/CookieAuthorizer.php
@@ -36,5 +36,7 @@ class CookieAuthorizer implements
         $this->authenticator->authenticate($client);
 
         $client->withHeader('Cookie', $this->authenticator->token());
+        $client->withHeader('Accept', "application/json");
+        $client->withHeader('Content-Type', "application/json");
     }
 }

--- a/src/Authorizer/TokenAuthorizer.php
+++ b/src/Authorizer/TokenAuthorizer.php
@@ -34,5 +34,7 @@ class TokenAuthorizer implements
         ClientInterface $client,
     ): void {
         $client->withHeader('Authorization', "Bearer {$this->token}");
+        $client->withHeader('Accept', "application/json");
+        $client->withHeader('Content-Type', "application/json");
     }
 }


### PR DESCRIPTION
See official documentation https://www.jetbrains.com/help/youtrack/devportal/api-query-syntax.html

Fixes error:
    Cog\Contracts\YouTrack\Rest\Client\Exceptions\ClientException
    {"error":"Unsupported Media Type","error_description":"HTTP 415 Unsupported Media Type"}