### PR TITLE
Fix attachments content-type

### DIFF
--- a/src/Authorizer/CookieAuthorizer.php
+++ b/src/Authorizer/CookieAuthorizer.php
@@ -35,7 +35,5 @@ class CookieAuthorizer implements
         $this->authenticator->authenticate($client);
 
         $client->withHeader('Cookie', $this->authenticator->token());
-        $client->withHeader('Accept', 'application/json');
-        $client->withHeader('Content-Type', 'application/json');
     }
 }

--- a/src/Authorizer/TokenAuthorizer.php
+++ b/src/Authorizer/TokenAuthorizer.php
@@ -33,7 +33,5 @@ class TokenAuthorizer implements
         ClientInterface $client,
     ): void {
         $client->withHeader('Authorization', "Bearer {$this->token}");
-        $client->withHeader('Accept', 'application/json');
-        $client->withHeader('Content-Type', 'application/json');
     }
 }

--- a/src/Client/YouTrackClient.php
+++ b/src/Client/YouTrackClient.php
@@ -248,6 +248,7 @@ class YouTrackClient implements
         $this->headers = [
             'User-Agent' => 'Cog-YouTrack-REST-PHP/' . self::VERSION,
             'Accept' => 'application/json',
+            'Content-Type' => 'application/json',
         ];
 
         $this->authorizer->appendHeadersTo($this);


### PR DESCRIPTION
- Follow up #63 
- Fixes #65 

Content-Type headers are overridable now:
```php
$client->post('/issues/TEST-1/attachments', [], [
    'multipart' => [[
        'name'     => 'upload',
        'contents' => 'dGVzdA==',
        'filename' => 'test.txt',
    ]],
    'headers' => [
        'Content-Type' => 'text/plain',
    ],
]);
```